### PR TITLE
Add assert

### DIFF
--- a/reedkiln.c
+++ b/reedkiln.c
@@ -111,6 +111,16 @@ void reedkiln_fail(void) {
   abort()/* in case the above doesn't work */;
 }
 
+void reedkiln_assert_ex
+  (int val, char const* text, char const* file, unsigned long int line)
+{
+  if (!val) {
+    fprintf(stdout, "## assert %s:%lu: %s\n", file, line, text);
+    reedkiln_fail();
+  }
+  return;
+}
+
 void reedkiln_bail_out(char const* reason) {
 #if defined(Reedkiln_Atomic)
   Reedkiln_Atomic_Put(&reedkiln_next_status, Reedkiln_NOT_OK);

--- a/reedkiln.h
+++ b/reedkiln.h
@@ -214,7 +214,7 @@ namespace reedkiln {
 #  if (defined Reedkiln_UseConstexpr)
     static constexpr reedkiln_box const* ptr = &value;
 #  else
-    static reedkiln_box const* ptr;
+    static reedkiln_box const* const ptr;
 #  endif /*Reedkiln_UseConstexpr*/
   };
   template <typename t>

--- a/reedkiln.h
+++ b/reedkiln.h
@@ -114,6 +114,22 @@ unsigned int reedkiln_rand(void);
 void reedkiln_memrand(void* b, reedkiln_size sz);
 
 /**
+ * @brief Report a fail if a condition is false (zero).
+ * @param val zero to fail, nonzero otherwise
+ * @param text a description of what (may have) failed
+ * @param file name of source file
+ * @param line line number of related source code
+ * @note Calls reedkiln_fail.
+ */
+void reedkiln_assert_ex
+  (int val, char const* text, char const* file, unsigned long int line);
+
+#if !(defined Reedkiln_NoAssert)
+#define reedkiln_assert(x) \
+    reedkiln_assert_ex((x), #x, __FILE__, __LINE__)
+#endif /*Reedkiln_NoAssert*/
+
+/**
  * @brief Run some tests.
  * @param t array of tests
  * @param argc from `main`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,5 +44,10 @@ if (Reedkiln_BUILD_TESTING AND BUILD_TESTING)
   add_test(NAME "reedkiln::bail" COMMAND reedkiln_test_bail)
   set_tests_properties("reedkiln::bail"
     PROPERTIES WILL_FAIL TRUE)
+
+  add_executable(reedkiln_test_assert "test_assert.c")
+  target_link_libraries(reedkiln_test_assert
+    PRIVATE reedkiln)
+  add_test(NAME "reedkiln::assert" COMMAND reedkiln_test_assert)
 endif (Reedkiln_BUILD_TESTING AND BUILD_TESTING)
 

--- a/tests/test_assert.c
+++ b/tests/test_assert.c
@@ -1,0 +1,42 @@
+/* SPDX-License-Identifier: Unlicense */
+#include "../reedkiln.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+int test_assert(void*);
+int test_assert_fail(void*);
+int test_zeta(void*);
+
+struct reedkiln_entry tests[] = {
+  { "assert", test_assert },
+  { "assert_fail", test_assert_fail, Reedkiln_TODO },
+  { "zeta", test_zeta },
+  { NULL, NULL }
+};
+
+/* test assertion processing */
+int test_assert(void* p) {
+  unsigned int v = reedkiln_rand();
+  unsigned int w = reedkiln_rand();
+  reedkiln_assert(v != w);
+  return Reedkiln_OK;
+}
+/* test assertion handling */
+int test_assert_fail(void* p) {
+  unsigned int v = reedkiln_rand();
+  unsigned int w = reedkiln_rand();
+  reedkiln_assert(v == w);
+  return Reedkiln_OK;
+}
+
+/* last test to run */
+int test_zeta(void* p) {
+  return Reedkiln_OK;
+}
+
+
+int main(int argc, char **argv) {
+  return reedkiln_main(tests, argc, argv, NULL);
+}

--- a/tests/test_cxx.cpp
+++ b/tests/test_cxx.cpp
@@ -42,6 +42,7 @@ public:
 };
 
 int test_cxx_raii(void*);
+int test_cxx_assert(void*);
 int test_cxx_setup(void*);
 int test_cxx_setupfail(void*);
 int test_memrand(void*);
@@ -52,6 +53,8 @@ int test_zeta(void*);
 
 struct reedkiln_entry tests[] = {
   { "cxx/raii", test_cxx_raii, Reedkiln_TODO },
+  { "cxx/assert", test_cxx_assert, Reedkiln_TODO,
+    reedkiln::cxx_box<std::string>::ptr },
   { "cxx/setup", test_cxx_setup, 0,
     reedkiln::cxx_box<std::string>::ptr },
   { "cxx/setupfail", test_cxx_setupfail, Reedkiln_TODO,
@@ -68,6 +71,15 @@ struct reedkiln_entry tests[] = {
 int test_cxx_raii(void* p) {
   free_box box(15);
   reedkiln_fail();
+  return Reedkiln_OK;
+}
+/* test cleanup with assert */
+int test_cxx_assert(void* p) {
+  std::string &str = *static_cast<std::string*>(p);
+  str.push_back('h');
+  str.append("ello,");
+  str += " world!";
+  reedkiln_assert(str.size() != 13);
   return Reedkiln_OK;
 }
 /* test auto-generated box */


### PR DESCRIPTION
This pull request adds support for a basic "assert" API.

The `reed kiln_assert` macro takes an expression, extracts
file name, line number and expression text, and reports
if the expression evaluates to false.