### PR TITLE
Add `reedkiln_log_write` API

### DIFF
--- a/log.h
+++ b/log.h
@@ -1,0 +1,202 @@
+/* SPDX-License-Identifier: Unlicense */
+/**
+ * @file log.h
+ * @brief Logging API for short tests.
+ */
+#if !defined(hg_Reedkiln_log_h_)
+#define hg_Reedkiln_log_h_
+
+#include "reedkiln.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /*__cplusplus*/
+
+
+/**
+ * @brief Write bytes to the log buffer.
+ * @param buffer bytes to write
+ * @param count number of bytes to write
+ * @return the number of bytes actually written
+ */
+reedkiln_size reedkiln_log_write(void const* buffer, reedkiln_size count);
+
+#if defined(__cplusplus)
+};
+#endif /*__cplusplus*/
+
+#if defined(__cplusplus)
+
+#include <streambuf>
+#include <ostream>
+#include <locale>
+#include <cwchar>
+
+namespace reedkiln {
+  /**
+   * @brief STL stream buffer implementation using Reedkiln's log.
+   * @tparam Ch character type
+   * @tparam Traits character traits type
+   */
+  template <typename Ch, typename Traits>
+  class cxx_logbuf : public std::basic_streambuf<Ch,Traits> {
+  public:
+    using typename std::basic_streambuf<Ch,Traits>::char_type;
+    using typename std::basic_streambuf<Ch,Traits>::int_type;
+  private:
+    using cvt_facet = std::codecvt<Ch,char,std::mbstate_t>;
+    cvt_facet const* cvt;
+    std::mbstate_t mbstate;
+    char_type buf[8];
+  public:
+    /** @brief Default constructor. */
+    cxx_logbuf() : cvt() {
+      resetp();
+    }
+    /** @brief Destructor. */
+    ~cxx_logbuf() { };
+    /**
+     * @brief Copy constructor.
+     * @param x stream buffer whose locale to imbue
+     */
+    cxx_logbuf(cxx_logbuf<Ch,Traits> const& x) : cvt() {
+      pubimbue(x.getloc());
+      resetp();
+    }
+    /**
+     * @brief Copy assignment operator.
+     * @param x stream buffer whose locale to imbue
+     * @return `*this`
+     */
+    cxx_logbuf& operator=(cxx_logbuf<Ch,Traits> const& x) {
+      pubimbue(x.getloc());
+      resetp();
+      return *this;
+    }
+  protected:
+    /**
+     * @brief `imbue` for `std::streambuf`.
+     * @param l locale to use
+     */
+    void imbue(std::locale const& l) {
+#if (defined Reedkiln_UseConstexpr)
+      constexpr std::mbstate_t zero = {};
+#else
+      std::mbstate_t zero = {};
+#endif /*Reedkiln_UseConstexpr*/
+      if (!std::has_facet<cvt_facet>(l))
+        cvt = nullptr;
+      else {
+        cvt_facet const& f = std::use_facet<cvt_facet>(l);
+        cvt = (f.always_noconv() ? nullptr : &f);
+      }
+      mbstate = zero;
+      return;
+    }
+    /**
+     * @brief `overflow` for `std::streambuf`
+     * @param ch additional character to add to put area
+     * @return zero
+     */
+    int_type overflow(int_type ch) {
+      sync();
+      if (ch != Traits::eof()) {
+        this->sputc(ch);
+      }
+      return 0;
+    }
+    /**
+     * @brief `xsputn` for `std::streambuf`
+     * @param s bulk data to add to log
+     * @param count number of `char_type` units to add
+     * @return count on success, less than count on encode error
+     * @note Overflow of associated Reedkiln log is ignored.
+     */
+    std::streamsize xsputn(char_type const* s, std::streamsize count) {
+      if ((!cvt) && sizeof(char_type) == sizeof(char)) {
+        sync();
+        reedkiln_log_write(s, static_cast<std::size_t>(count));
+        return count;
+      } else {
+        std::streamsize i;
+        for (i = 0; i < count; ++i) {
+          int const put_result = this->sputc(s[i]);
+          if (put_result == Traits::eof())
+            break;
+        }
+        return i;
+      }
+    }
+    /**
+     * @brief `sync` for `std::streambuf`
+     * @return zero on success, negative on encode error
+     */
+    int sync() {
+      char outbuf[32];
+      const char_type* from_next = this->pbase();
+      const char_type* const from_end = this->pptr();
+      char* to_next = outbuf;
+      char* const to_end = outbuf + sizeof(outbuf);
+      std::codecvt_base::result res;
+      if (from_next == from_end)
+        return 0;
+      else if (!cvt) {
+        for (; from_next < from_end; ++from_next, ++to_next) {
+          if (to_next == to_end) {
+            reedkiln_log_write(outbuf, to_next - outbuf);
+            to_next = outbuf;
+          }
+          *to_next = static_cast<char>(*from_next);
+        }
+        if (to_next > outbuf)
+          reedkiln_log_write(outbuf, to_next - outbuf);
+        res = std::codecvt_base::ok;
+      } else {
+        res = cvt->out(mbstate, from_next, from_end, from_next,
+            outbuf, outbuf+sizeof(outbuf), to_next);
+        while (res == std::codecvt_base::partial) {
+          reedkiln_log_write(outbuf, to_next - outbuf);
+          res = cvt->out(mbstate, from_next, from_end, from_next,
+                outbuf, outbuf+sizeof(outbuf), to_next);
+        }
+        if (to_next > outbuf)
+          reedkiln_log_write(outbuf, to_next - outbuf);
+      }
+      resetp();
+      return (res == std::codecvt_base::error) ? -1 : 0;
+    }
+  private:
+    void resetp() {
+      this->setp(buf,buf+8);
+    }
+  };
+
+  /**
+   * @brief Get the narrow STL stream for the Reedkiln log.
+   * @return a reference to a std::ostream
+   */
+  inline
+  std::ostream& cxx_log() {
+    using buf_type =
+      cxx_logbuf<std::ostream::char_type, std::ostream::traits_type>;
+    static buf_type buf;
+    static std::ostream os(&buf);
+    return os;
+  }
+  /**
+   * @brief Get the wide STL stream for the Reedkiln log.
+   * @return a reference to a std::wostream
+   */
+  inline
+  std::wostream& cxx_wlog() {
+    using buf_type =
+      cxx_logbuf<std::wostream::char_type, std::wostream::traits_type>;
+    static buf_type buf;
+    static std::wostream os(&buf);
+    return os;
+  }
+};
+
+#endif /*__cplusplus*/
+
+#endif /*hg_Reedkiln_log_h_*/

--- a/reedkiln.h
+++ b/reedkiln.h
@@ -140,6 +140,8 @@ void reedkiln_assert_ex
  * @param argv from `main`
  * @param p to pass to the callbacks
  * @return an exit code
+ * @note This library assumes at most one `reedkiln_main` per process
+ *   is running at a time.
  */
 int reedkiln_main
     (struct reedkiln_entry const* t, int argc, char **argv, void* p);

--- a/tests/test_assert.c
+++ b/tests/test_assert.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: Unlicense */
 #include "../reedkiln.h"
+#include "../log.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,6 +10,7 @@ int test_assert(void*);
 int test_assert_fail(void*);
 int test_explicit_false(void*);
 int test_explicit_true(void*);
+int test_message(void*);
 int test_zeta(void*);
 
 struct reedkiln_entry tests[] = {
@@ -16,6 +18,7 @@ struct reedkiln_entry tests[] = {
   { "assert_fail", test_assert_fail, Reedkiln_TODO },
   { "explicit_false", test_explicit_false, Reedkiln_TODO },
   { "explicit_true", test_explicit_true },
+  { "message", test_message },
   { "zeta", test_zeta },
   { NULL, NULL }
 };
@@ -32,6 +35,12 @@ int test_assert_fail(void* p) {
   unsigned int v = reedkiln_rand();
   unsigned int w = reedkiln_rand();
   reedkiln_assert(v == w);
+  return Reedkiln_OK;
+}
+/* test message output */
+int test_message(void* p) {
+  char const str[] = "Hello, world!";
+  reedkiln_log_write(str, sizeof(str)-1);
   return Reedkiln_OK;
 }
 

--- a/tests/test_cxx.cpp
+++ b/tests/test_cxx.cpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 #include "../reedkiln.h"
+#include "../log.h"
 #include <string>
 #include <iostream>
+#include <iomanip>
 #include <cstring>
 
 class free_box {
@@ -52,6 +54,9 @@ public:
 
 int test_cxx_raii(void*);
 int test_cxx_assert(void*);
+int test_cxx_log(void*);
+int test_cxx_wlog(void*);
+int test_cxx_log_numbers(void*);
 int test_cxx_setup(void*);
 int test_cxx_setupfail(void*);
 int test_memrand(void*);
@@ -66,6 +71,9 @@ struct reedkiln_entry tests[] = {
   { "cxx/raii", test_cxx_raii, Reedkiln_TODO },
   { "cxx/assert", test_cxx_assert, Reedkiln_TODO,
     reedkiln::cxx_box<std::string>::ptr },
+  { "cxx/log", test_cxx_log },
+  { "cxx/wlog", test_cxx_wlog },
+  { "cxx/log/numbers", test_cxx_log_numbers },
   { "cxx/setup", test_cxx_setup, 0,
     reedkiln::cxx_box<std::string>::ptr },
   { "cxx/setupfail", test_cxx_setupfail, Reedkiln_TODO,
@@ -95,6 +103,30 @@ int test_cxx_assert(void* p) {
   reedkiln_assert(str.size() != 13);
   return Reedkiln_OK;
 }
+
+/* test c++ narrow logging */
+int test_cxx_log(void* p) {
+  reedkiln::cxx_log() << "Hello, world!";
+  return Reedkiln_OK;
+}
+/* test c++ wide logging */
+int test_cxx_wlog(void* p) {
+  reedkiln::cxx_wlog() << L"Hello, world!" << std::flush;
+  return Reedkiln_OK;
+}
+/* test c++ narrow logging */
+int test_cxx_log_numbers(void* p) {
+  unsigned int num = reedkiln_rand();
+  unsigned int other = reedkiln_rand();
+  reedkiln::cxx_log() << num << ' ';
+  reedkiln::cxx_log() << num*256.0/static_cast<double>(other);
+  reedkiln::cxx_log() << " " << -1.0;
+  reedkiln::cxx_log() << " " << &num;
+  reedkiln::cxx_log() << ' ' << std::hex << other;
+  reedkiln::cxx_log() << ' ' << std::dec << other;
+  return Reedkiln_OK;
+}
+
 /* test auto-generated box */
 int test_cxx_setup(void* p) {
   std::string &str = *static_cast<std::string*>(p);


### PR DESCRIPTION
This pull request adds support for a logging buffer, used to generate YAML messages, following the examples given in the Test Anything Protocol.

Closes #4.

Tests on Ubuntu 22 seem to work correctly.