### PR TITLE
Add `reedkiln_log_printf` API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 /out
 /.vs
+/.vscode
 .DS_Store
 *~
 *.swp

--- a/log.h
+++ b/log.h
@@ -8,6 +8,20 @@
 
 #include "reedkiln.h"
 
+#if (defined __GNUC__)
+#  define Reedkiln_attrPrintf(y,z) __attribute__((format(printf,y,z)))
+#else
+/** @brief Macro for activating `printf` warnings. */
+#  define Reedkiln_attrPrintf(y,z)
+#endif /*__GNUC__*/
+
+#if (defined _MSC_VER) && (_MSC_VER >= 1910)
+#  include <sal.h>
+#  define Reedkiln_argPrintf _Printf_format_string_
+#else
+#  define Reedkiln_argPrintf
+#endif /*_MSC_VER*/
+
 #if defined(__cplusplus)
 extern "C" {
 #endif /*__cplusplus*/
@@ -20,6 +34,14 @@ extern "C" {
  * @return the number of bytes actually written
  */
 reedkiln_size reedkiln_log_write(void const* buffer, reedkiln_size count);
+/**
+ * @brief Writes formatted output to the log buffer.
+ * @param format printf-style format
+ * @return the number of bytes actually written
+ */
+reedkiln_size reedkiln_log_printf(Reedkiln_argPrintf char const* format, ...)
+  Reedkiln_attrPrintf(1,2);
+
 
 #if defined(__cplusplus)
 };

--- a/log.h
+++ b/log.h
@@ -38,6 +38,12 @@ reedkiln_size reedkiln_log_write(void const* buffer, reedkiln_size count);
  * @brief Writes formatted output to the log buffer.
  * @param format printf-style format
  * @return the number of bytes actually written
+ * @note When compiled without C99 support, this function uses a shim
+ *   that supports a small subset of format specifiers:
+ *   `%%`, `%a`, `%La`, `%i`, `%li`, `%zi`,
+ *   `%x`, `%lx`, `%zx`, `%p`, `%s`, `%ls`.
+ *   This shim also supports precison for `%s`, and otherwise accounts
+ *   for `%*.*i` additional arguments.
  */
 reedkiln_size reedkiln_log_printf(Reedkiln_argPrintf char const* format, ...)
   Reedkiln_attrPrintf(1,2);

--- a/reedkiln.c
+++ b/reedkiln.c
@@ -40,7 +40,7 @@
 static void Reedkiln_Atomic_Put(unsigned int volatile* c, unsigned int v) {
   *c = v;
 }
-static unsigned int Reedkiln_Atomic_Get(unsigned int volatile* c) {
+static unsigned int Reedkiln_Atomic_Get(unsigned int const volatile* c) {
   return *c;
 }
 #  define Reedkiln_Atomic

--- a/reedkiln.c
+++ b/reedkiln.c
@@ -425,7 +425,7 @@ reedkiln_size reedkiln_log_printf(char const* format, ...) {
        ? reedkiln_log_size - src : count);
     va_list ap;
     va_start(ap, format);
-    (void)reedkiln_log_vsnprintf(ptr->data, put_length, format, ap);
+    (void)reedkiln_log_vsnprintf(ptr->data+src, put_length, format, ap);
     va_end(ap);
     return (unsigned int)put_length;
   }

--- a/reedkiln.c
+++ b/reedkiln.c
@@ -602,7 +602,7 @@ int reedkiln_log_vsnprintf
 {
   unsigned int count = 0;
 #if (defined __STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
-  count = vsnprintf(output, sz, format, ap);
+  count = vsnprintf((char*)output, sz, format, ap);
 #else
   char const* p;
   for (p = format; *p; ++p) {
@@ -673,7 +673,7 @@ int reedkiln_log_vsnprintf
       case 'x':
         {
           reedkiln_intmax value;
-          char ibuffer[Reedkiln_ItoXMax];
+          unsigned char ibuffer[Reedkiln_ItoXMax];
           int ilen;
           if (*p == 'p')
             value = (reedkiln_intmax)va_arg(ap, void const*);
@@ -704,7 +704,7 @@ int reedkiln_log_vsnprintf
         {
           reedkiln_intmax value;
           reedkiln_intmax valuemax;
-          char ibuffer[Reedkiln_ItoXMax];
+          unsigned char ibuffer[Reedkiln_ItoXMax];
           int ilen;
           if (type_adjust <= -2) {
             value = va_arg(ap, unsigned int)&UCHAR_MAX;
@@ -742,7 +742,7 @@ int reedkiln_log_vsnprintf
       case 'A':
         {
           long double value;
-          char dbuffer[Reedkiln_DtoXMax];
+          unsigned char dbuffer[Reedkiln_DtoXMax];
           int dlen = 0;
           char sign = 0;
           char prefix = 1;
@@ -774,7 +774,7 @@ int reedkiln_log_vsnprintf
             if (prefix)
               count = reedkiln_log_count_strn(output, sz, count, 2,"0x");
             count = reedkiln_log_count_strn
-              (output, sz, count, dlen, dbuffer);
+              (output, sz, count, dlen, (char*)dbuffer);
           }
         } break;
       case '%':

--- a/tests/test_assert.c
+++ b/tests/test_assert.c
@@ -76,14 +76,14 @@ int test_message(void* p) {
 }
 /* test message output : %% */
 int test_message_percent(void* p) {
-  int bytes = reedkiln_log_printf("100%%");
+  size_t bytes = reedkiln_log_printf("100%%");
   reedkiln_assert(bytes == 5);
   return Reedkiln_OK;
 }
 /* test message output : %s */
 int test_message_s(void* p) {
   char const str[] = "Hello, world!";
-  int bytes = reedkiln_log_printf("Quotation: \"%s\"", str);
+  size_t bytes = reedkiln_log_printf("Quotation: \"%s\"", str);
   reedkiln_assert(bytes == 13+14);
   return Reedkiln_OK;
 }
@@ -91,7 +91,7 @@ int test_message_s(void* p) {
 int test_message_s_precision(void* p) {
   char const str[] = "abcdefghijklm";
   unsigned int const num = reedkiln_rand()%12;
-  int bytes = reedkiln_log_printf("Quotation: \"%.*s\" %.5s",
+  size_t bytes = reedkiln_log_printf("Quotation: \"%.*s\" %.5s",
     num, str, str);
   reedkiln_assert(bytes == 15+num+5);
   return Reedkiln_OK;
@@ -100,7 +100,7 @@ int test_message_s_precision(void* p) {
 int test_message_ls(void* p) {
   wchar_t const str[] = L"Hello, world!";
   wchar_t const str2[] = { 0x101, 0x250C, 0 };
-  int bytes = reedkiln_log_printf("Wide %ls: ", str);
+  size_t bytes = reedkiln_log_printf("Wide %ls: ", str);
   reedkiln_log_printf("%ls", str2);
   reedkiln_assert(bytes == 8+13);
   return Reedkiln_OK;
@@ -109,15 +109,15 @@ int test_message_ls(void* p) {
 int test_message_ls_precision(void* p) {
   wchar_t const str[] = L"abcdefghijklm";
   unsigned int const num = reedkiln_rand()%12;
-  int bytes = reedkiln_log_printf("Wide %.*ls", num, str);
+  size_t bytes = reedkiln_log_printf("Wide %.*ls", num, str);
   reedkiln_assert(bytes == 6+num);
   return Reedkiln_OK;
 }
 /* test message output : %x */
 int test_message_x(void* p) {
   unsigned int num = reedkiln_rand();
-  int bytes = reedkiln_log_printf("Number %x.", num);
-  int expected = 0;
+  size_t bytes = reedkiln_log_printf("Number %x.", num);
+  size_t expected = 0;
   if (num == 0)
     expected = 1;
   else while (num > 0) {
@@ -129,20 +129,20 @@ int test_message_x(void* p) {
 }
 /* test message output : %p */
 int test_message_p(void* p) {
-  int bytes = reedkiln_log_printf("Pointer %p != %p.", &p, NULL);
+  size_t bytes = reedkiln_log_printf("Pointer %p != %p.", &p, NULL);
   reedkiln_assert(bytes > 10);
   return Reedkiln_OK;
 }
 /* test message output : %a */
 int test_message_a(void* p) {
-  int bytes = reedkiln_log_printf("Float %a %a %a %a.",
+  size_t bytes = reedkiln_log_printf("Float %a %a %a %a.",
     1.0, 0.0, -1.0, HUGE_VAL);
   reedkiln_assert(bytes >= 10+7);
   return Reedkiln_OK;
 }
 /* test message output : %a at the limits */
 int test_message_a_limits(void* p) {
-  int bytes = reedkiln_log_printf("Float %a %a %a %a.",
+  size_t bytes = reedkiln_log_printf("Float %a %a %a %a.",
     DBL_MAX, DBL_MIN, DBL_EPSILON, FLT_EPSILON);
   reedkiln_assert(bytes >= 10+7);
   return Reedkiln_OK;
@@ -152,7 +152,7 @@ int test_message_a_rand(void* p) {
   unsigned int num = reedkiln_rand();
   double v = ((num&1) ? -1.0 : 1.0) * (num * 256.0 / UINT_MAX);
   double w = ((num&1) ? -1.0 : 1.0) * (num / 256.0 / UINT_MAX);
-  int bytes = reedkiln_log_printf("%a * %a = %a;", v, w, v*w);
+  size_t bytes = reedkiln_log_printf("%a * %a = %a;", v, w, v*w);
   reedkiln_assert(bytes > 10);
   return Reedkiln_OK;
 }
@@ -161,7 +161,7 @@ int test_message_a_rand(void* p) {
 int test_message_i(void* p) {
   unsigned int num = reedkiln_rand()%INT_MAX;
   unsigned int const old_num = num;
-  int bytes = reedkiln_log_printf("Number %i.", old_num);
+  size_t bytes = reedkiln_log_printf("Number %i.", old_num);
   int expected = 0;
   if (num == 0)
     expected = 1;
@@ -177,7 +177,7 @@ int test_message_x_precision(void* p) {
   size_t const positive = ((~(size_t)0)>>1);
   size_t num = (reedkiln_rand()*(size_t)12345) & positive;
   size_t const old_num = num;
-  int bytes = reedkiln_log_printf("Number %0zX.", old_num);
+  size_t bytes = reedkiln_log_printf("Number %0zX.", old_num);
   int expected = 0;
   if (num == 0)
     expected = 1;
@@ -193,8 +193,8 @@ int test_message_i_precision(void* p) {
   size_t const positive = ((~(size_t)0)>>1);
   size_t num = (reedkiln_rand()*(size_t)12345) & positive;
   size_t const old_num = num;
-  int bytes = reedkiln_log_printf("Number %*.*zi.", 1, 1, old_num);
-  int expected = 0;
+  size_t bytes = reedkiln_log_printf("Number %*.*zi.", 1, 1, old_num);
+  size_t expected = 0;
   if (num == 0)
     expected = 1;
   else while (num > 0) {
@@ -207,8 +207,8 @@ int test_message_i_precision(void* p) {
 /* test message output : %i negative */
 int test_message_i_negative(void* p) {
   int const old_num = -(int)(reedkiln_rand()%INT_MAX);
-  int bytes = reedkiln_log_printf("Number %i.", old_num);
-  int expected = 0;
+  size_t bytes = reedkiln_log_printf("Number %i.", old_num);
+  size_t expected = 0;
   int num = -old_num;
   if (num == 0)
     expected = 0;

--- a/tests/test_assert.c
+++ b/tests/test_assert.c
@@ -28,6 +28,7 @@ int test_message_a_rand(void*);
 int test_message_i(void*);
 int test_message_i_negative(void*);
 int test_message_i_precision(void*);
+int test_message_i_size(void*);
 int test_zeta(void*);
 
 struct reedkiln_entry tests[] = {
@@ -50,6 +51,7 @@ struct reedkiln_entry tests[] = {
   { "message_i", test_message_i },
   { "message_i/precision", test_message_i_precision },
   { "message_i/negative", test_message_i_negative },
+  { "message_i/size", test_message_i_size },
   { "zeta", test_zeta },
   { NULL, NULL }
 };
@@ -194,6 +196,23 @@ int test_message_i_precision(void* p) {
   size_t num = (reedkiln_rand()*(size_t)12345) & positive;
   size_t const old_num = num;
   size_t bytes = reedkiln_log_printf("Number %*.*zi.", 1, 1, old_num);
+  size_t expected = 0;
+  if (num == 0)
+    expected = 1;
+  else while (num > 0) {
+    num /= 10;
+    expected += 1;
+  }
+  reedkiln_assert(bytes == expected+9);
+  return Reedkiln_OK;
+}
+
+/* test message output : %zi */
+int test_message_i_size(void* p) {
+  size_t const positive = ((~(size_t)0)>>1);
+  size_t num = (reedkiln_rand()*(size_t)12345) & positive;
+  size_t const old_num = num;
+  size_t bytes = reedkiln_log_printf("Number %zi.", old_num);
   size_t expected = 0;
   if (num == 0)
     expected = 1;

--- a/tests/test_assert.c
+++ b/tests/test_assert.c
@@ -4,6 +4,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
+#include <math.h>
+#include <float.h>
 
 
 int test_assert(void*);
@@ -11,6 +14,20 @@ int test_assert_fail(void*);
 int test_explicit_false(void*);
 int test_explicit_true(void*);
 int test_message(void*);
+int test_message_percent(void*);
+int test_message_s(void*);
+int test_message_s_precision(void*);
+int test_message_ls(void*);
+int test_message_ls_precision(void*);
+int test_message_x(void*);
+int test_message_x_precision(void*);
+int test_message_p(void*);
+int test_message_a(void*);
+int test_message_a_limits(void*);
+int test_message_a_rand(void*);
+int test_message_i(void*);
+int test_message_i_negative(void*);
+int test_message_i_precision(void*);
 int test_zeta(void*);
 
 struct reedkiln_entry tests[] = {
@@ -19,6 +36,20 @@ struct reedkiln_entry tests[] = {
   { "explicit_false", test_explicit_false, Reedkiln_TODO },
   { "explicit_true", test_explicit_true },
   { "message", test_message },
+  { "message_percent", test_message_percent },
+  { "message_s", test_message_s },
+  { "message_s/precision", test_message_s_precision },
+  { "message_ls", test_message_ls },
+  { "message_ls/precision", test_message_ls_precision },
+  { "message_x", test_message_x },
+  { "message_x/precision", test_message_x_precision },
+  { "message_p", test_message_p },
+  { "message_a", test_message_a },
+  { "message_a/limits", test_message_a_limits },
+  { "message_a/rand", test_message_a_rand },
+  { "message_i", test_message_i },
+  { "message_i/precision", test_message_i_precision },
+  { "message_i/negative", test_message_i_negative },
   { "zeta", test_zeta },
   { NULL, NULL }
 };
@@ -43,7 +74,151 @@ int test_message(void* p) {
   reedkiln_log_write(str, sizeof(str)-1);
   return Reedkiln_OK;
 }
+/* test message output : %% */
+int test_message_percent(void* p) {
+  int bytes = reedkiln_log_printf("100%%");
+  reedkiln_assert(bytes == 5);
+  return Reedkiln_OK;
+}
+/* test message output : %s */
+int test_message_s(void* p) {
+  char const str[] = "Hello, world!";
+  int bytes = reedkiln_log_printf("Quotation: \"%s\"", str);
+  reedkiln_assert(bytes == 13+14);
+  return Reedkiln_OK;
+}
+/* test message output : %*s */
+int test_message_s_precision(void* p) {
+  char const str[] = "abcdefghijklm";
+  unsigned int const num = reedkiln_rand()%12;
+  int bytes = reedkiln_log_printf("Quotation: \"%.*s\" %.5s",
+    num, str, str);
+  reedkiln_assert(bytes == 15+num+5);
+  return Reedkiln_OK;
+}
+/* test message output : %ls */
+int test_message_ls(void* p) {
+  wchar_t const str[] = L"Hello, world!";
+  wchar_t const str2[] = { 0x101, 0x250C, 0 };
+  int bytes = reedkiln_log_printf("Wide %ls: ", str);
+  reedkiln_log_printf("%ls", str2);
+  reedkiln_assert(bytes == 8+13);
+  return Reedkiln_OK;
+}
+/* test message output : %.*ls */
+int test_message_ls_precision(void* p) {
+  wchar_t const str[] = L"abcdefghijklm";
+  unsigned int const num = reedkiln_rand()%12;
+  int bytes = reedkiln_log_printf("Wide %.*ls", num, str);
+  reedkiln_assert(bytes == 6+num);
+  return Reedkiln_OK;
+}
+/* test message output : %x */
+int test_message_x(void* p) {
+  unsigned int num = reedkiln_rand();
+  int bytes = reedkiln_log_printf("Number %x.", num);
+  int expected = 0;
+  if (num == 0)
+    expected = 1;
+  else while (num > 0) {
+    num >>= 4;
+    expected += 1;
+  }
+  reedkiln_assert(bytes == expected+9);
+  return Reedkiln_OK;
+}
+/* test message output : %p */
+int test_message_p(void* p) {
+  int bytes = reedkiln_log_printf("Pointer %p != %p.", &p, NULL);
+  reedkiln_assert(bytes > 10);
+  return Reedkiln_OK;
+}
+/* test message output : %a */
+int test_message_a(void* p) {
+  int bytes = reedkiln_log_printf("Float %a %a %a %a.",
+    1.0, 0.0, -1.0, HUGE_VAL);
+  reedkiln_assert(bytes >= 10+7);
+  return Reedkiln_OK;
+}
+/* test message output : %a at the limits */
+int test_message_a_limits(void* p) {
+  int bytes = reedkiln_log_printf("Float %a %a %a %a.",
+    DBL_MAX, DBL_MIN, DBL_EPSILON, FLT_EPSILON);
+  reedkiln_assert(bytes >= 10+7);
+  return Reedkiln_OK;
+}
+/* test message output : %a with random inputs */
+int test_message_a_rand(void* p) {
+  unsigned int num = reedkiln_rand();
+  double v = ((num&1) ? -1.0 : 1.0) * (num * 256.0 / UINT_MAX);
+  double w = ((num&1) ? -1.0 : 1.0) * (num / 256.0 / UINT_MAX);
+  int bytes = reedkiln_log_printf("%a * %a = %a;", v, w, v*w);
+  reedkiln_assert(bytes > 10);
+  return Reedkiln_OK;
+}
 
+/* test message output : %i */
+int test_message_i(void* p) {
+  unsigned int num = reedkiln_rand()%INT_MAX;
+  unsigned int const old_num = num;
+  int bytes = reedkiln_log_printf("Number %i.", old_num);
+  int expected = 0;
+  if (num == 0)
+    expected = 1;
+  else while (num > 0) {
+    num /= 10;
+    expected += 1;
+  }
+  reedkiln_assert(bytes == expected+9);
+  return Reedkiln_OK;
+}
+/* test message output : %zx */
+int test_message_x_precision(void* p) {
+  size_t const positive = ((~(size_t)0)>>1);
+  size_t num = (reedkiln_rand()*(size_t)12345) & positive;
+  size_t const old_num = num;
+  int bytes = reedkiln_log_printf("Number %0zX.", old_num);
+  int expected = 0;
+  if (num == 0)
+    expected = 1;
+  else while (num > 0) {
+    num >>= 4;
+    expected += 1;
+  }
+  reedkiln_assert(bytes == expected+9);
+  return Reedkiln_OK;
+}
+/* test message output : %*.*zi */
+int test_message_i_precision(void* p) {
+  size_t const positive = ((~(size_t)0)>>1);
+  size_t num = (reedkiln_rand()*(size_t)12345) & positive;
+  size_t const old_num = num;
+  int bytes = reedkiln_log_printf("Number %*.*zi.", 1, 1, old_num);
+  int expected = 0;
+  if (num == 0)
+    expected = 1;
+  else while (num > 0) {
+    num /= 10;
+    expected += 1;
+  }
+  reedkiln_assert(bytes == expected+9);
+  return Reedkiln_OK;
+}
+/* test message output : %i negative */
+int test_message_i_negative(void* p) {
+  int const old_num = -(int)(reedkiln_rand()%INT_MAX);
+  int bytes = reedkiln_log_printf("Number %i.", old_num);
+  int expected = 0;
+  int num = -old_num;
+  if (num == 0)
+    expected = 0;
+  else while (num > 0) {
+    num /= 10;
+    expected += 1;
+  }
+  reedkiln_assert(bytes == expected+10);
+  return Reedkiln_OK;
+}
 /* test for assert conversion to Boolean false */
 int test_explicit_false(void* p) {
   reedkiln_assert(NULL);


### PR DESCRIPTION
This pull request adds support for `printf`-style formatting onto the new logging buffer.

Closes #8.

Tests pass on Ubuntu 22.04.