### PR TITLE
Mark C main as noexcept false

### DIFF
--- a/reedkiln.h
+++ b/reedkiln.h
@@ -144,7 +144,11 @@ void reedkiln_assert_ex
  *   is running at a time.
  */
 int reedkiln_main
-    (struct reedkiln_entry const* t, int argc, char **argv, void* p);
+    (struct reedkiln_entry const* t, int argc, char **argv, void* p)
+#if (defined __cplusplus) && (defined Reedkiln_UseNoexcept)
+    noexcept(false)
+#endif //__cplusplus && Reedkiln_UseNoexcept
+    ;
 
 /**
  * @brief Configure the failure code path.


### PR DESCRIPTION
Release mode Windows doesn't expect an exception to be thrown through `reedkiln_main`. So when the `reedkiln::reset` test allows this, the Windows C++ runtime breaks.

This pull request marks `reedkiln_main` as `noexcept(false)` to notify the compiler to prepare appropriately.

Closes #16.